### PR TITLE
Error with abraham/twitteroauth 

### DIFF
--- a/src/TwitterChannel.php
+++ b/src/TwitterChannel.php
@@ -39,7 +39,7 @@ class TwitterChannel
         $twitterApiResponse = $this->twitter->post(
             $twitterMessage->getApiEndpoint(),
             $requestBody,
-            $twitterMessage->isJsonRequest,
+            ['jsonPayload' => $twitterMessage->isJsonRequest],
         );
 
         if ($this->twitter->getLastHttpCode() !== 201) {


### PR DESCRIPTION
It seems like the base package `abraham/twitteroauth` did some changes, and I'm now getting an error: 

```
Abraham\TwitterOAuth\TwitterOAuth::post(): Argument #3 ($options) must be of type array, true given, called in /home/forge/xxx/vendor/laravel-notification-channels/twitter/src/TwitterChannel.php on line 39
```

This PR has a patch to change that to an array, and it seems to fix it in all my local tests. 

